### PR TITLE
Fixed prev button and year formatting

### DIFF
--- a/src/brick-calendar.js
+++ b/src/brick-calendar.js
@@ -565,7 +565,7 @@
     monthEl.setAttribute('role', 'grid');
     // create month label
     var monthLabel = makeEl('div.month-label');
-    monthLabel.textContent = labels.months[month] + ' ' + d.getYear();
+    monthLabel.textContent = labels.months[month] + ' ' + d.getFullYear();
 
     monthEl.appendChild(monthLabel);
 
@@ -1398,7 +1398,7 @@
 
     this.ns.listeners.clickPrev = delegate(".prev", function (e) {
       var xCalendar = e.currentTarget;
-      xCalendar.nextMonth();
+      xCalendar.prevMonth();
       xCalendar.dispatchEvent(new CustomEvent("prevmonth",{
         bubbles:true
       }));


### PR DESCRIPTION
Previous year button was using the nextMonth() method;
The year wasn’t displaying properly using getYear(), I swapped it out
for getFullYear();
